### PR TITLE
Atualização currículo

### DIFF
--- a/cv.css
+++ b/cv.css
@@ -1,0 +1,311 @@
+/* =========================================================
+   CV page — reuses the "Constellation" palette from the
+   portfolio (navy / copper / teal, Lora + Inter) in a
+   print-ready, two-column resume layout.
+   ========================================================= */
+
+:root {
+  --navy: #0b1220;
+  --navy-soft: #141d33;
+  --star: #eef2ff;
+
+  --paper: #ffffff;
+  --ink: #1c2430;
+  --ink-soft: #5b6472;
+  --line: #e2e4e8;
+
+  --copper: #b5651d;
+  --copper-soft: #f4e3d0;
+  --teal: #12796f;
+  --teal-soft: #d9f0ec;
+
+  --font-display: "Lora", Georgia, "Times New Roman", serif;
+  --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: #eef1f6;
+  color: var(--ink);
+  font-family: var(--font-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--teal); }
+
+/* ---------- toolbar (screen only) ---------- */
+
+.cv-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 960px;
+  margin: 1.5rem auto 0;
+  padding: 0 1rem;
+  font-family: var(--font-body);
+}
+
+.cv-toolbar a {
+  color: var(--ink-soft);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+.cv-toolbar a:hover { color: var(--teal); }
+
+#print-btn {
+  background: var(--teal);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.6rem 1.1rem;
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+#print-btn:hover { background: #0d5f57; }
+
+/* ---------- page ---------- */
+
+.cv-page {
+  max-width: 960px;
+  margin: 1.25rem auto 3rem;
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  background: var(--paper);
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 8px 30px rgba(11, 18, 32, 0.12);
+}
+
+/* ---------- sidebar ---------- */
+
+.cv-sidebar {
+  background: radial-gradient(120% 120% at 30% 0%, var(--navy-soft) 0%, var(--navy) 60%);
+  color: var(--star);
+  padding: 2rem 1.5rem;
+}
+
+.cv-photo {
+  width: 108px;
+  height: 108px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid var(--teal);
+  margin: 0 auto 1rem;
+  display: block;
+}
+
+.cv-name {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  text-align: center;
+  margin: 0 0 0.25rem;
+  color: #fff;
+}
+
+.cv-role {
+  text-align: center;
+  font-size: 0.85rem;
+  color: #b9c2d9;
+  margin: 0 0 1.75rem;
+  line-height: 1.4;
+}
+
+.cv-side-block {
+  margin-bottom: 1.6rem;
+}
+
+.cv-side-block h2 {
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--teal-soft);
+  border-bottom: 1px solid rgba(238, 242, 255, 0.2);
+  padding-bottom: 0.35rem;
+  margin: 0 0 0.7rem;
+}
+
+.cv-side-block h3 {
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #8fa0c6;
+  margin: 0.8rem 0 0.25rem;
+}
+
+.cv-contact, .cv-plain-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 0.82rem;
+}
+.cv-contact li, .cv-plain-list li {
+  margin-bottom: 0.5rem;
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  color: #dbe1f0;
+  word-break: break-word;
+}
+.cv-contact a, .cv-plain-list a {
+  color: #dbe1f0;
+  text-decoration: none;
+}
+.cv-contact a:hover { color: #fff; text-decoration: underline; }
+
+.cv-icon { color: var(--copper); flex: none; }
+
+.cv-tag {
+  margin-left: auto;
+  font-size: 0.68rem;
+  color: #8fa0c6;
+}
+
+.cv-skill-line {
+  font-size: 0.8rem;
+  color: #cdd6ec;
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* ---------- main column ---------- */
+
+.cv-main {
+  padding: 2rem 2.2rem;
+}
+
+.cv-main-header {
+  border-bottom: 2px solid var(--copper);
+  padding-bottom: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.cv-headline {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  color: var(--ink);
+  margin: 0;
+}
+
+.cv-block { margin-bottom: 1.8rem; }
+.cv-block:last-of-type { margin-bottom: 0; }
+
+.cv-block > h2 {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  color: var(--navy);
+  margin: 0 0 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+.cv-block > h2::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--line);
+}
+
+.cv-block p { margin: 0 0 0.7rem; font-size: 0.9rem; color: var(--ink); }
+.cv-block p:last-child { margin-bottom: 0; }
+
+.cv-entry { margin-bottom: 1.3rem; }
+.cv-entry:last-child { margin-bottom: 0; }
+.cv-entry-compact { margin-bottom: 0.6rem; }
+
+.cv-entry-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 0.3rem;
+}
+
+.cv-entry-head h3 {
+  font-family: var(--font-body);
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--ink);
+  margin: 0;
+}
+
+.cv-entry-sub {
+  font-weight: 500;
+  color: var(--teal);
+  font-size: 0.85rem;
+}
+
+.cv-entry-date {
+  font-size: 0.78rem;
+  color: var(--ink-soft);
+  white-space: nowrap;
+  flex: none;
+}
+
+.cv-entry p {
+  font-size: 0.87rem;
+  color: var(--ink-soft);
+  margin: 0 0 0.4rem;
+}
+
+.cv-stack {
+  font-size: 0.78rem;
+  color: var(--copper);
+  font-weight: 600;
+}
+
+.cv-bullets {
+  margin: 0.3rem 0 0;
+  padding-left: 1.1rem;
+  font-size: 0.87rem;
+  color: var(--ink-soft);
+}
+.cv-bullets li { margin-bottom: 0.25rem; }
+
+.cv-keywords {
+  font-size: 0.72rem;
+  color: var(--line);
+  margin-top: 1.5rem;
+}
+
+/* ---------- responsive ---------- */
+
+@media (max-width: 760px) {
+  .cv-page { grid-template-columns: 1fr; }
+  .cv-sidebar { padding: 1.75rem 1.5rem; }
+}
+
+/* ---------- print ---------- */
+
+@media print {
+  @page { size: A4; margin: 12mm; }
+
+  .no-print { display: none !important; }
+
+  body { background: #fff; }
+
+  .cv-page {
+    box-shadow: none;
+    border-radius: 0;
+    margin: 0;
+    max-width: none;
+    grid-template-columns: 250px 1fr;
+  }
+
+  .cv-sidebar {
+    background: var(--navy) !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .cv-main { padding: 0 0 0 1.5rem; }
+
+  .cv-block { break-inside: avoid; }
+  .cv-entry { break-inside: avoid; }
+}

--- a/cv.html
+++ b/cv.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Rui Margarido | Curriculum Vitae</title>
+  <meta name="description" content="Rui Margarido — Software Engineer & Mechanical Engineer. Curriculum vitae: Java, .NET, Python, AI/LLM systems, Industry 4.0 background.">
+  <meta name="robots" content="noindex">
+  <link rel="canonical" href="https://ruigrmargarido.github.io/cv.html">
+  <link rel="icon" type="image/x-icon" href="favicon2.png">
+  <link rel="stylesheet" href="cv.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+<div class="cv-toolbar no-print">
+  <a href="index.html">&larr; Back to portfolio</a>
+  <button id="print-btn" type="button">Download / Print PDF</button>
+</div>
+
+<main class="cv-page">
+
+  <aside class="cv-sidebar">
+    <img class="cv-photo" src="Eu.jpg" alt="Portrait of Rui Margarido">
+    <h1 class="cv-name">Rui Margarido</h1>
+    <p class="cv-role">Software Engineer<br>Mechanical Engineer</p>
+
+    <section class="cv-side-block">
+      <h2>Contact</h2>
+      <ul class="cv-contact">
+        <li><span class="cv-icon" aria-hidden="true">&#9993;</span> <a href="mailto:ruigrm@gmail.com">ruigrm@gmail.com</a></li>
+        <li><span class="cv-icon" aria-hidden="true">&#9742;</span> +351 914 507 784</li>
+        <li><span class="cv-icon" aria-hidden="true">&#9679;</span> Mira, Coimbra, Portugal</li>
+        <li><span class="cv-icon" aria-hidden="true">&#8599;</span> <a href="https://ruigrmargarido.github.io/" target="_blank" rel="noopener">ruigrmargarido.github.io</a></li>
+        <li><span class="cv-icon" aria-hidden="true">&#8599;</span> <a href="https://www.linkedin.com/in/rui-margarido-4a5b49142" target="_blank" rel="noopener">linkedin.com/in/rui-margarido</a></li>
+        <li><span class="cv-icon" aria-hidden="true">&#8599;</span> <a href="https://github.com/RuiGRMargarido" target="_blank" rel="noopener">github.com/RuiGRMargarido</a></li>
+      </ul>
+    </section>
+
+    <section class="cv-side-block">
+      <h2>Languages</h2>
+      <ul class="cv-plain-list">
+        <li>Portuguese <span class="cv-tag">Native</span></li>
+        <li>English <span class="cv-tag">Advanced</span></li>
+      </ul>
+    </section>
+
+    <section class="cv-side-block">
+      <h2>Core Skills</h2>
+
+      <h3>Languages</h3>
+      <p class="cv-skill-line">Java · C# · Python · TypeScript/JavaScript · C · SQL · PL/SQL · Prolog</p>
+
+      <h3>Backend &amp; Architecture</h3>
+      <p class="cv-skill-line">ASP.NET Core · FastAPI · REST APIs · Clean Architecture · DDD · Entity Framework Core · JWT · OAuth2/OIDC</p>
+
+      <h3>Frontend</h3>
+      <p class="cv-skill-line">Angular · React · Next.js · TypeScript · Three.js</p>
+
+      <h3>AI &amp; Data</h3>
+      <p class="cv-skill-line">LLM Orchestration · RAG · Explainable AI (SHAP/LIME) · scikit-learn · Pandas · Power BI</p>
+
+      <h3>Databases</h3>
+      <p class="cv-skill-line">SQL Server · PostgreSQL · MongoDB · Oracle · Qdrant</p>
+
+      <h3>DevOps &amp; Cloud</h3>
+      <p class="cv-skill-line">Docker · Git/GitHub Actions · CI/CD · Azure · Linux</p>
+
+      <h3>Testing &amp; Methods</h3>
+      <p class="cv-skill-line">TDD · Pytest · Playwright (E2E) · SCRUM/Agile</p>
+    </section>
+
+    <section class="cv-side-block">
+      <h2>Certifications</h2>
+      <ul class="cv-plain-list">
+        <li>Ordem dos Engenheiros — Member No. 86522</li>
+        <li>HVAC Designer — AS Formação, 2021</li>
+        <li>Continuous Improvement — Kaizen Institute, 2016</li>
+        <li>SolidWorks Essentials Plus — Sqedio, 2016</li>
+      </ul>
+    </section>
+  </aside>
+
+  <section class="cv-main">
+
+    <header class="cv-main-header">
+      <p class="cv-headline">Software Engineer · Mechanical Engineer &nbsp;|&nbsp; Java · .NET · Python &nbsp;|&nbsp; AI/LLM Systems · Industry 4.0</p>
+    </header>
+
+    <section class="cv-block">
+      <h2>Profile</h2>
+      <p>
+        Engineer with a dual background in Mechanical and Software Engineering. Completed a Bachelor's
+        degree in Software Engineering at ISEP in 2026, after 11 years of industrial experience in
+        production management, process engineering and KPI-driven decision making — a foundation that
+        now shapes a pragmatic, outcomes-focused approach to software.
+      </p>
+      <p>
+        Throughout the degree, built complete end-to-end systems: a port logistics platform in
+        .NET/Angular with Prolog-based intelligent planning, and an LLM-based conversational system
+        (RAG, explainable AI) for energy forecasting, developed in a research environment (GECAD/ISEP).
+        Core stack centers on Java/.NET/Python for backend, Angular/React for frontend, and
+        Docker/CI/CD/Azure for DevOps.
+      </p>
+      <p>
+        Looking for a first full-time Software Engineer role, ideally where software connects to real
+        systems — Industry 4.0, automation, applied data/AI, or critical infrastructure. Open to remote
+        (Europe) and hybrid roles in Portugal.
+      </p>
+    </section>
+
+    <section class="cv-block">
+      <h2>Featured Projects</h2>
+
+      <article class="cv-entry">
+        <div class="cv-entry-head">
+          <h3>XAI Energy Chatbot <span class="cv-entry-sub">Final-Year Project · GECAD/ISEP</span></h3>
+          <span class="cv-entry-date">2025 – 2026</span>
+        </div>
+        <p>
+          LLM-based conversational system letting users query energy forecasting models and their
+          explainability artifacts (SHAP, LIME, PDP, ALE) in natural language. Clean Architecture
+          backend orchestrating a local LLM, a RAG layer over validated documentation (Qdrant), and an
+          external forecasting API, backed by PostgreSQL. Covered by unit, integration and E2E
+          (Playwright) tests with a CI pipeline.
+        </p>
+        <p class="cv-stack">Python · FastAPI · Next.js/React/TypeScript · RAG · Qdrant · PostgreSQL · Docker · CI/CD</p>
+      </article>
+
+      <article class="cv-entry">
+        <div class="cv-entry-head">
+          <h3>Sustainable Port Logistics Management <span class="cv-entry-sub">Integrative Project · ISEP, 5th semester</span></h3>
+          <span class="cv-entry-date">2025 – 2026</span>
+        </div>
+        <p>
+          Port operations platform covering vessel scheduling, dock assignment and cargo manifests,
+          with a genetic-algorithm planner in Prolog. Decoupled .NET Web APIs (Clean Architecture/DDD),
+          a Node.js/Keycloak authentication service and an Angular SPA with a Three.js 3D visualization.
+          Built over three SCRUM sprints, deployed via CI/CD to Azure.
+        </p>
+        <p class="cv-stack">C# · .NET · Entity Framework Core · Angular · Prolog · MongoDB · OAuth2/OIDC · Azure</p>
+      </article>
+
+      <article class="cv-entry">
+        <div class="cv-entry-head">
+          <h3>PTD Load Prediction <span class="cv-entry-sub">ANADI — Machine Learning</span></h3>
+          <span class="cv-entry-date">2025 – 2026</span>
+        </div>
+        <p>
+          Supervised ML models predicting available capacity and utilization for 72,027 distribution
+          transformer stations on Portugal's national grid (E-Redes). Neural network as best performer,
+          validated with cross-validation and statistical hypothesis testing.
+        </p>
+        <p class="cv-stack">Python · scikit-learn · Pandas · GridSearchCV · Jupyter Notebook</p>
+      </article>
+    </section>
+
+    <section class="cv-block">
+      <h2>Professional Experience</h2>
+
+      <article class="cv-entry">
+        <div class="cv-entry-head">
+          <h3>Production Manager <span class="cv-entry-sub">Baptista e Irmão SA</span></h3>
+          <span class="cv-entry-date">04/2018 – 08/2025</span>
+        </div>
+        <p>
+          Managed production at a welded-wire-mesh factory with a high level of automation
+          (Industry 4.0), reporting to the board. Concluded the role after 7 years to complete the
+          software engineering degree.
+        </p>
+        <ul class="cv-bullets">
+          <li>Continuous process improvement, waste reduction and resource optimization</li>
+          <li>Defined and monitored production KPIs to support decision-making</li>
+          <li>Managed preventive/reactive maintenance planning and raw-material stock</li>
+        </ul>
+      </article>
+
+      <article class="cv-entry">
+        <div class="cv-entry-head">
+          <h3>Production &amp; Industrialization Engineer <span class="cv-entry-sub">LWC Metal (TESTA Group)</span></h3>
+          <span class="cv-entry-date">02/2016 – 03/2018</span>
+        </div>
+        <ul class="cv-bullets">
+          <li>Implemented laser/punch cutting and bending processes and workflows</li>
+          <li>Implemented the company's production management system</li>
+          <li>Industrialization of high-complexity products and product cost analysis</li>
+        </ul>
+      </article>
+
+      <article class="cv-entry">
+        <div class="cv-entry-head">
+          <h3>Process Engineer <span class="cv-entry-sub">Jamarcol</span></h3>
+          <span class="cv-entry-date">04/2014 – 01/2016</span>
+        </div>
+        <ul class="cv-bullets">
+          <li>Implemented laser tube cutting and associated precision metalworking processes</li>
+          <li>Coordinated daily production activities and priorities</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="cv-block">
+      <h2>Education</h2>
+      <article class="cv-entry cv-entry-compact">
+        <div class="cv-entry-head">
+          <h3>Bachelor's Degree in Software Engineering <span class="cv-entry-sub">Instituto Superior de Engenharia do Porto (ISEP)</span></h3>
+          <span class="cv-entry-date">2023 – 2026</span>
+        </div>
+      </article>
+      <article class="cv-entry cv-entry-compact">
+        <div class="cv-entry-head">
+          <h3>Integrated Master's Degree in Mechanical Engineering <span class="cv-entry-sub">Universidade de Aveiro</span></h3>
+          <span class="cv-entry-date">2008 – 2013</span>
+        </div>
+      </article>
+    </section>
+
+    <p class="cv-keywords no-print">
+      Additional keywords: IIoT · SCADA · MES · OT Security · Lean · Kaizen · Microservices ·
+      Production Management · Cloud
+    </p>
+
+  </section>
+
+</main>
+
+<script>
+  document.getElementById('print-btn').addEventListener('click', function () {
+    window.print();
+  });
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
       <span class="nav-title2">Mechanical Experience</span>
       <span class="nav-title2-mobile">Experience</span>
     </a></li>
+    <li><a href="cv.html">CV</a></li>
     <li>
       <a href="https://www.linkedin.com/in/rui-margarido-4a5b49142/" target="_blank" rel="noopener">
         <img src="free-linkedin-logo.png" alt="LinkedIn" class="social-icon">
@@ -96,6 +97,7 @@
       <p>My journey began in Mechanical Engineering, where I developed a practical mindset and learned the value of precision, responsibility, and teamwork. Over time, my curiosity led me towards Software Engineering and a new way of solving problems. Today, I see these fields not as separate paths, but as complementary perspectives that allow me to approach challenges with both practical experience and creative thinking.</p>
       <p>I value continuous learning and enjoy taking on projects that push me beyond what I already know. More than working with a particular technology, what motivates me is the opportunity to build something useful, overcome a difficult challenge, and see an idea gradually come to life.</p>
       <p>Away from engineering, I enjoy spending time with family and friends, playing video games, watching football, anime, and comedy films, and reading about technology, personal development, and financial education. I live in Mira, a quiet Portuguese village between Aveiro and Coimbra, where I appreciate the balance between ambition and a grounded way of life.</p>
+      <a class="doc-link" href="cv.html">📄 View / Download CV</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Resumo
- Cria uma página de CV dedicada (`cv.html` + `cv.css`) com design apelativo, alinhado à identidade visual do portfólio (paleta navy/copper/teal, tipografia Lora + Inter), em layout de duas colunas pronto para impressão/exportação em PDF (botão "Download / Print PDF").
- Liga a nova página a partir da navbar (`CV`) e da secção **About Me** (`📄 View / Download CV`).
- Atualiza o conteúdo do CV para refletir o estado atual real, sincronizado com o portfólio:
  - Licenciatura em Engenharia Informática (ISEP) marcada como **concluída (2026)**, deixando de aparecer "em curso"
  - Cargo de Production Manager na Baptista e Irmão SA marcado como **concluído (08/2025)**
  - Substitui os 3 projetos académicos antigos por **3 projetos de destaque mais recentes e fortes**: XAI Energy Chatbot (LLM/RAG/Explainable AI, GECAD/ISEP), Sustainable Port Logistics Management (.NET/Angular/Prolog/Three.js), PTD Load Prediction (Machine Learning, ANADI)
  - Stack técnica ampliada com o que já é real (Python, React, Next.js, PostgreSQL, MongoDB, Clean Architecture, RAG, LLM Orchestration) em vez de "a aprender"

## Propostas para decisão
1. **Headline do CV** — atual: `Software Engineer · Mechanical Engineer | Java · .NET · Python | AI/LLM Systems · Industry 4.0`. Alternativa mais curta/software-first: `Software Engineer | Java · .NET · Python | AI-Driven Systems`. Manter a versão dupla-formação ajuda no fit para nichos industriais (Industry 4.0/OT), a alternativa favorece candidaturas software-only.
2. **Projetos em destaque** — selecionei os 3 mais fortes para caber numa página. Alternativa: incluir um 4.º projeto (Drone Light Show, mais técnico em C/Java/sockets) se o CV for para uma vaga muito backend/sistemas.
3. **Fotografia no CV** — atualmente inclui a foto (`Eu.jpg`) na sidebar, como no portfólio. Em candidaturas para mercados como Reino Unido/EUA é comum omitir a foto — posso criar uma variante sem foto se for necessário.
4. **Exportação em PDF** — o botão imprime via `window.print()` com CSS dedicado para A4. Não gerei um PDF estático porque o conteúdo pode mudar; se preferires um PDF fixo versionado no repo (como os antigos em `career-profile/docs/cv/`), digo-te como gerar.

## Ficheiros relacionados (fora deste PR)
Atualizei também `career-profile/profile/cv.md` (v2.0) e `career-profile/profile/alteracoes-cv.md` no repositório `career-profile`, para manter o CV mestre em Markdown sincronizado com esta página — essas alterações não fazem parte deste PR (repositório diferente).

## Test plan
- [x] Conteúdo verificado via preview local (servidor estático), sem erros de consola
- [ ] Confirmar visualmente o layout em browser real (desktop + mobile)
- [ ] Testar "Download / Print PDF" num browser real e validar a paginação A4