### PR TITLE
Update footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -978,7 +978,21 @@
 </main>
 
 <footer>
-  <p>&copy; 2024 by Rui Margarido. Proudly created with HTML, CSS and a little bit of Javascript</p>
+  <p class="footer-name">Rui Margarido</p>
+  <p class="footer-tagline">Software Engineer &middot; Mechanical Engineer</p>
+  <ul class="footer-socials">
+    <li>
+      <a href="https://www.linkedin.com/in/rui-margarido-4a5b49142/" target="_blank" rel="noopener" aria-label="LinkedIn profile">
+        <img src="free-linkedin-logo.png" alt="">
+      </a>
+    </li>
+    <li>
+      <a href="https://github.com/RuiGRMargarido/RuiGRMargarido.github.io" target="_blank" rel="noopener" aria-label="GitHub profile">
+        <img src="GitHub-Logo-3821918866.png" alt="">
+      </a>
+    </li>
+  </ul>
+  <p class="footer-copyright">&copy; 2024&ndash;2026 Rui Margarido</p>
 </footer>
 
 <script>

--- a/styles.css
+++ b/styles.css
@@ -872,6 +872,48 @@ footer {
   text-align: center;
   padding: 3rem 1.5rem;
   color: var(--ink-soft);
-  font-size: 0.85rem;
   border-top: 1px solid var(--line);
+}
+.footer-name {
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 0 0 0.3em;
+}
+.footer-tagline {
+  font-size: 0.95rem;
+  margin: 0 0 1.5rem;
+}
+.footer-socials {
+  list-style: none;
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  margin: 0 0 1.5rem;
+  padding: 0;
+}
+.footer-socials a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: var(--paper-raised);
+  border: 1px solid var(--line);
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+.footer-socials a:hover, .footer-socials a:focus-visible {
+  border-color: var(--teal);
+  transform: translateY(-2px);
+}
+.footer-socials img {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+}
+.footer-copyright {
+  font-size: 0.85rem;
+  margin: 0;
 }


### PR DESCRIPTION
## Summary
- Replaces the single outdated footer line with a fuller close: name + tagline, LinkedIn/GitHub social icons (matching the hero/nav), and a corrected copyright (2024–2026).

Closes #18