### PR TITLE
Mobile visual fixes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -263,6 +263,15 @@ a:hover, a:focus-visible {
   .nav-title-mobile, .nav-title2-mobile {
     display: inline;
   }
+  #navbar ul {
+    padding: 1rem 1.5rem;
+    gap: 0.3rem 1.1rem;
+  }
+  #navbar li:first-child {
+    flex-basis: 100%;
+    text-align: center;
+    margin-bottom: 0.3rem;
+  }
 }
 .social-icon {
   width: 28px;
@@ -874,4 +883,16 @@ footer {
   color: var(--ink-soft);
   font-size: 0.85rem;
   border-top: 1px solid var(--line);
+}
+/* Justified text can leave large, uneven word gaps on narrow lines;
+   left-align body copy on small viewports instead. */
+@media (max-width: 640px) {
+  .about-text p,
+  .journey-intro,
+  .section-content > p,
+  .experience-details p,
+  .project-item p {
+    text-align: left;
+    hyphens: none;
+  }
 }


### PR DESCRIPTION
## Summary
Found during a mobile visual QA pass:
- Sticky nav wrapped awkwardly on narrow screens (logo crammed next to "About" with a huge gap, LinkedIn icon isolated on its own line). Fixed by giving the logo its own row.
- Justified body text (`text-align: justify`) left large, uneven word gaps on short lines across About, Journey, Software Projects and Mechanical Experience at mobile widths. Switched to left-aligned below 640px; desktop justify is untouched.

Closes #20