### PR TITLE
Fix nav wrapping on wider mobile screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
       <span class="nav-title">Software Projects</span>
       <span class="nav-title-mobile">Projects</span>
     </a></li>
+    <li class="nav-break" aria-hidden="true"></li>
     <li><a href="#experience">
       <span class="nav-title2">Mechanical Experience</span>
       <span class="nav-title2-mobile">Experience</span>

--- a/styles.css
+++ b/styles.css
@@ -255,6 +255,9 @@ a:hover, a:focus-visible {
 .nav-title-mobile, .nav-title2-mobile {
   display: none;
 }
+.nav-break {
+  display: none;
+}
 
 @media (max-width: 640px) {
   .nav-title, .nav-title2 {
@@ -271,6 +274,14 @@ a:hover, a:focus-visible {
     flex-basis: 100%;
     text-align: center;
     margin-bottom: 0.3rem;
+  }
+  .nav-break {
+    display: block;
+    flex-basis: 100%;
+    width: 0;
+    height: 0;
+    margin: 0;
+    padding: 0;
   }
 }
 .social-icon {


### PR DESCRIPTION
## Summary
- On wider mobile screens (e.g. iPhone XR, 414px), the nav's natural flex-wrap let "About Journey Projects Experience" all fit on one line, leaving the LinkedIn icon isolated alone on the next line — inconsistent with the already-correct behavior at 375px (Experience + icon grouped together).
- Adds an invisible `<li class="nav-break">` between "Projects" and "Experience" (hidden by default, `flex-basis: 100%` only under the mobile media query) to force a consistent line break regardless of exact viewport width. Desktop nav is unaffected.

Closes #22