### PR TITLE
botao

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -200,6 +200,29 @@ a:hover, a:focus-visible {
   background: rgba(238, 242, 255, 0.85);
   animation: scroll-cue-move 1.8s ease-in-out infinite;
 }
+
+/* Keep the scroll cue in the hero's content flow when vertical space is
+   limited, so it always remains below the social links. */
+@media (max-width: 640px), (max-height: 820px) {
+  .hero {
+    flex-direction: column;
+    padding: 1rem 0;
+  }
+
+  .hero-inner {
+    padding-bottom: 0;
+  }
+
+  .scroll-cue {
+    position: relative;
+    left: auto;
+    bottom: auto;
+    transform: none;
+    flex: 0 0 auto;
+    margin-top: 1rem;
+  }
+}
+
 @keyframes scroll-cue-move {
   0%   { top: 8px; opacity: 1; }
   70%  { top: 20px; opacity: 0.2; }


### PR DESCRIPTION
## O que foi alterado

- Coloca o indicador de scroll no fluxo vertical do hero em ecrãs estreitos ou com pouca altura.
- Mantém uma separação de 16 px entre os ícones sociais e o indicador.
- Preserva o posicionamento original em ecrãs desktop com altura normal.

## Motivo

O indicador estava posicionado de forma absoluta no fundo do hero. Em viewports baixos, os ícones do LinkedIn e GitHub aproximavam-se dessa área e sobrepunham-se ao indicador.

## Impacto

A área inicial fica legível e os três controlos permanecem separados em telemóveis e ecrãs baixos, sem alterações de conteúdo ou comportamento no restante site.

## Validação

- Teste visual e medição de sobreposição em 390×667, 390×844, 1894×804 e 1440×900.
- Build de produção com `npm run build` concluído com sucesso.
- Sem erros na consola do browser.
